### PR TITLE
Fixed check for ID.

### DIFF
--- a/TeensyCANBase.cpp
+++ b/TeensyCANBase.cpp
@@ -21,8 +21,8 @@ int TeensyCANBase::read(byte* &msg) {
 	if (CANbus.read(rxmsg)) {
 		if (rxmsg.id == canID){
 			memcpy(msg, rxmsg.buf, 8);
+			return 0;
 		}
-		return 0;
 	}
 	return 1;
 }


### PR DESCRIPTION
It was returning 0 when the ID was incorrect, leading
to message reuse.
