### PR TITLE
CAN ID fix and writing

### DIFF
--- a/AbstractTeensyCAN.cpp
+++ b/AbstractTeensyCAN.cpp
@@ -7,7 +7,7 @@
    @param id: the CAN ID
 */
 AbstractTeensyCAN::AbstractTeensyCAN(uint32_t id){
-	canID = 0x00000FFF & id; // This ensures that all memory not set is 0
+	canID = id; // This ensures that all memory not set is 0
 }
 
 /**

--- a/AbstractTeensyCAN.cpp
+++ b/AbstractTeensyCAN.cpp
@@ -7,8 +7,7 @@
    @param id: the CAN ID
 */
 AbstractTeensyCAN::AbstractTeensyCAN(uint32_t id){
-	canID = 0; // This ensures that all memory not set is 0
-	canID += id;
+	canID = 0x00000FFF & id; // This ensures that all memory not set is 0
 }
 
 /**

--- a/AbstractTeensyCAN.cpp
+++ b/AbstractTeensyCAN.cpp
@@ -6,7 +6,10 @@
    the CAN ID is needed.
    @param id: the CAN ID
 */
-AbstractTeensyCAN::AbstractTeensyCAN(uint32_t id) : canID(id){}
+AbstractTeensyCAN::AbstractTeensyCAN(uint32_t id){
+	canID = 0; // This ensures that all memory not set is 0
+	canID += id;
+}
 
 /**
    Returns the classes's ID

--- a/AbstractTeensyCAN.h
+++ b/AbstractTeensyCAN.h
@@ -32,7 +32,7 @@ public:
 	   @param resp: the CAN response (8 bytes long)
 	   @return: 0 to send response, 1 to hold
 	 */
-	virtual int call(byte* msg, byte* resp) = 0;
+	virtual int call(byte* msg) = 0;
 protected:
 	/**
 	   The ID of CAN messages to read/write

--- a/AbstractTeensyCAN.h
+++ b/AbstractTeensyCAN.h
@@ -32,7 +32,7 @@ public:
 	   @param resp: the CAN response (8 bytes long)
 	   @return: 0 to send response, 1 to hold
 	 */
-	virtual int call(byte* msg) = 0;
+	virtual void call(byte* msg) = 0;
 protected:
 	/**
 	   The ID of CAN messages to read/write

--- a/TeensyCANBase.cpp
+++ b/TeensyCANBase.cpp
@@ -26,7 +26,7 @@ public:
 	   @param id the message ID that this class will respond to (0x600-0x6FF)
 	   @param callback the function that this class will call
 	 */
-	TeensyCANFunction(uint32_t id, int (*callback)(byte* msg));
+	TeensyCANFunction(uint32_t id, void (*callback)(byte* msg));
 
 	/**
 	   Call the function with the CAN message and response
@@ -35,12 +35,12 @@ public:
 	   @return the return of the callback function
 	   0 means send, 1 means do not send
 	 */
-	int call(byte* msg);
+	void call(byte* msg);
 protected:
 	/**
 	    The callback function for this instance
 	  */
-	int (*callback)(byte* msg);
+	void (*callback)(byte* msg);
 
 };
 
@@ -134,7 +134,7 @@ void CAN_add(AbstractTeensyCAN * newAbstractTeensyCAN){
    0 means that resp is non-empty
    1 means that resp is empty and should not be sent
 */
-void CAN_add_id(uint32_t id, int (*callback)(byte* msg)){
+void CAN_add_id(uint32_t id, void (*callback)(byte* msg)){
 	uint32_t messageID = 0; // This ensures that all memory not set is 0
 	messageID += id;
 	TeensyCANFunction * teensyCANFunction = new TeensyCANFunction(messageID, callback); // Cleanup occurs in remove
@@ -198,7 +198,7 @@ void CAN_remove_id(uint32_t id){
    @param id the message ID that this class will respond to
    @param callback the function that this class will call
 */
-TeensyCANFunction::TeensyCANFunction(uint32_t id, int (*callback)(byte* msg))
+TeensyCANFunction::TeensyCANFunction(uint32_t id, void (*callback)(byte* msg))
 	: AbstractTeensyCAN(id), callback(callback){}
 
 /**
@@ -208,6 +208,6 @@ TeensyCANFunction::TeensyCANFunction(uint32_t id, int (*callback)(byte* msg))
    @return the return of the callback function
    0 means send, 1 means do not send
 */
-int TeensyCANFunction::call(byte * msg){
-	return callback(msg);
+void TeensyCANFunction::call(byte * msg){
+	callback(msg);
 }

--- a/TeensyCANBase.cpp
+++ b/TeensyCANBase.cpp
@@ -23,7 +23,7 @@ class TeensyCANFunction : public AbstractTeensyCAN{
 public:
 	/**
 	   Constructor
-	   @param id the message ID that this class will respond to
+	   @param id the message ID that this class will respond to (0x600-0x6FF)
 	   @param callback the function that this class will call
 	 */
 	TeensyCANFunction(uint32_t id, int (*callback)(byte* msg, byte* resp));
@@ -50,7 +50,7 @@ protected:
  */
 void CAN_begin(){
 	CANbus = new FlexCAN(1000000);
-	CANbus->begin();
+	CANbus->begin(0x6FF); // 0x6FF is the filter
 }
 
 /**

--- a/TeensyCANBase.cpp
+++ b/TeensyCANBase.cpp
@@ -117,7 +117,7 @@ void CAN_end(){
    When the AbstractTeensyCAN's ID is detected in a message, the
    call function will be called
 */
-void CAN_add_id(AbstractTeensyCAN * newAbstractTeensyCAN){
+void CAN_add(AbstractTeensyCAN * newAbstractTeensyCAN){
 	if(firstNode == NULL){
 		firstNode = new LinkedListNode<AbstractTeensyCAN>;
 		firstNode->data = newAbstractTeensyCAN;

--- a/TeensyCANBase.cpp
+++ b/TeensyCANBase.cpp
@@ -53,8 +53,8 @@ void CAN_begin(){
 	CAN_filter_t filter;
 	filter.rtr = 0;
 	filter.ext = 0;
-	filter.id = 0x6FF; // Change this for different IDs
-	CANbus->begin(filter);
+	filter.id = 0x0FFFFFFF; // Change this for different IDs
+	CANbus->begin();
 }
 
 /**
@@ -135,7 +135,9 @@ void CAN_add(AbstractTeensyCAN * newAbstractTeensyCAN){
    1 means that resp is empty and should not be sent
 */
 void CAN_add_id(uint32_t id, int (*callback)(byte* msg)){
-	TeensyCANFunction * teensyCANFunction = new TeensyCANFunction(id, callback); // Cleanup occurs in remove
+	uint32_t messageID = 0; // This ensures that all memory not set is 0
+	messageID += id;
+	TeensyCANFunction * teensyCANFunction = new TeensyCANFunction(messageID, callback); // Cleanup occurs in remove
 
 	if(firstNode == NULL){
 		firstNode = new LinkedListNode<AbstractTeensyCAN>;
@@ -153,7 +155,8 @@ void CAN_add_id(uint32_t id, int (*callback)(byte* msg)){
 void CAN_write(uint32_t id, byte * msg){
 	CAN_message_t txmsg;
 
-	txmsg.id = id;
+	txmsg.id = 0; // This ensures that all memory not set is 0
+	txmsg.id += id;
 	txmsg.len = 8;
 
 	memcpy(txmsg.buf, msg, 8);

--- a/TeensyCANBase.cpp
+++ b/TeensyCANBase.cpp
@@ -50,10 +50,6 @@ protected:
  */
 void CAN_begin(){
 	CANbus = new FlexCAN(1000000);
-	CAN_filter_t filter;
-	filter.rtr = 0;
-	filter.ext = 0;
-	filter.id = 0x0FFFFFFF; // Change this for different IDs
 	CANbus->begin();
 }
 
@@ -135,9 +131,7 @@ void CAN_add(AbstractTeensyCAN * newAbstractTeensyCAN){
    1 means that resp is empty and should not be sent
 */
 void CAN_add_id(uint32_t id, void (*callback)(byte* msg)){
-	uint32_t messageID = 0; // This ensures that all memory not set is 0
-	messageID += id;
-	TeensyCANFunction * teensyCANFunction = new TeensyCANFunction(messageID, callback); // Cleanup occurs in remove
+	TeensyCANFunction * teensyCANFunction = new TeensyCANFunction(id, callback); // Cleanup occurs in remove
 
 	if(firstNode == NULL){
 		firstNode = new LinkedListNode<AbstractTeensyCAN>;
@@ -155,8 +149,7 @@ void CAN_add_id(uint32_t id, void (*callback)(byte* msg)){
 void CAN_write(uint32_t id, byte * msg){
 	CAN_message_t txmsg;
 
-	txmsg.id = 0; // This ensures that all memory not set is 0
-	txmsg.id += id;
+	txmsg.id = 0x00000FFF & id; // This ensures that all memory not set is 0
 	txmsg.len = 8;
 
 	memcpy(txmsg.buf, msg, 8);

--- a/TeensyCANBase.cpp
+++ b/TeensyCANBase.cpp
@@ -149,7 +149,7 @@ void CAN_add_id(uint32_t id, void (*callback)(byte* msg)){
 void CAN_write(uint32_t id, byte * msg){
 	CAN_message_t txmsg;
 
-	txmsg.id = 0x00000FFF & id; // This ensures that all memory not set is 0
+	txmsg.id = id;
 	txmsg.len = 8;
 
 	memcpy(txmsg.buf, msg, 8);

--- a/TeensyCANBase.cpp
+++ b/TeensyCANBase.cpp
@@ -112,9 +112,35 @@ void CAN_end(){
 }
 
 /**
-   Function that adds a new TeensyCANFunction class
-   to the linked list given an id and a callback
-   For usage, see documentation in the header file
+   Function that adds an instance of a AbstractTeensyCAN class
+   @param TeensyCAN the class to connect to CAN
+   When the AbstractTeensyCAN's ID is detected in a message, the
+   call function will be called
+*/
+void CAN_add_id(AbstractTeensyCAN * newAbstractTeensyCAN){
+	if(firstNode == NULL){
+		firstNode = new LinkedListNode<AbstractTeensyCAN>;
+		firstNode->data = newAbstractTeensyCAN;
+		firstNode->next = NULL;
+	}
+	else{
+		LinkedListNode<AbstractTeensyCAN> * lastFirst = firstNode;
+		firstNode = new LinkedListNode<AbstractTeensyCAN>;
+		firstNode->data = newAbstractTeensyCAN;
+		firstNode->next = lastFirst;
+	}
+}
+
+/**
+   Function that adds another CAN ID and callback
+   @param id the message ID that this instance responds to
+   @param callback the function that this instance will call
+   when it recieves a message
+   The parameter msg is the 8 bytes that the message contained
+   The parameter resp is the 8 bytes that the function returns
+   The function returns an integer status
+   0 means that resp is non-empty
+   1 means that resp is empty and should not be sent
 */
 void CAN_add_id(uint32_t id, int (*callback)(byte* msg, byte* resp)){
 	TeensyCANFunction * teensyCANFunction = new TeensyCANFunction(id, callback); // Cleanup occurs in remove

--- a/TeensyCANBase.h
+++ b/TeensyCANBase.h
@@ -31,7 +31,7 @@ void CAN_end();
    0 means that resp is non-empty
    1 means that resp is empty and should not be sent
 */
-void CAN_add_id(uint32_t id, int (*callback)(byte* msg, byte* resp));
+void CAN_add_id(uint32_t id, int (*callback)(byte* msg));
 /**
    Function that adds an instance of a AbstractTeensyCAN class
    @param TeensyCAN the class to connect to CAN
@@ -39,6 +39,8 @@ void CAN_add_id(uint32_t id, int (*callback)(byte* msg, byte* resp));
    call function will be called
 */
 void CAN_add(AbstractTeensyCAN * TeensyCAN);
+
+void CAN_write(uint32_t id, byte * msg);
 
 /**
    Removes a CAN ID

--- a/TeensyCANBase.h
+++ b/TeensyCANBase.h
@@ -31,7 +31,7 @@ void CAN_end();
    0 means that resp is non-empty
    1 means that resp is empty and should not be sent
 */
-void CAN_add_id(uint32_t id, int (*callback)(byte* msg));
+void CAN_add_id(uint32_t id, void (*callback)(byte* msg));
 /**
    Function that adds an instance of a AbstractTeensyCAN class
    @param TeensyCAN the class to connect to CAN

--- a/TeensyCANBase.h
+++ b/TeensyCANBase.h
@@ -22,7 +22,7 @@ void CAN_update();
 void CAN_end();
 /**
    Function that adds another CAN ID and callback
-   @param id the message ID that this instance responds to
+   @param id the message ID that this instance responds to (0x600-0x6FF)
    @param callback the function that this instance will call
    when it recieves a message
    The parameter msg is the 8 bytes that the message contained


### PR DESCRIPTION
This is to fix an ongoing issue with CAN reading and implement a better sensor management system upon that being fixed.
According to typical CAN system designs, sensors should be pushing data constantly. Previously, we were using a call and response system. This pull request adds an easy function for sending data.
There was previously an error where, due to incorrectly initialized CAN ids on the Teensy side, most messages were being lost. In addition, the mask on the RoboRIO side had an error that was leading to further message loss, although this was introduced more recently.

The Teensy ID initialization is fixed here, and a function is added to allow for writing directly.